### PR TITLE
Fix build issues by using local fonts and exporting sport data

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -85,8 +85,8 @@
 }
 
 @theme inline {
-  --font-heading: var(--font-heading);
-  --font-body: var(--font-body);
+  --font-heading: var(--font-geist-sans);
+  --font-body: var(--font-geist-sans);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,24 +1,14 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Playfair_Display, Source_Sans_3 as Source_Sans_Pro } from "next/font/google"
+import { GeistSans } from "geist/font/sans"
 import "./globals.css"
 import { StructuredDataScript } from "@/components/structured-data"
 import { generateSportsTeamStructuredData } from "@/lib/structured-data"
 import { ThemeProvider } from "next-themes"
 
-const playfairDisplay = Playfair_Display({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-heading",
-  weight: ["400", "700"],
-})
-
-const sourceSansPro = Source_Sans_Pro({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-body",
-  weight: ["400", "600"],
-})
+// Use the locally bundled Geist Sans font to avoid network requests during
+// build. This ensures the application can compile in environments without
+// external font access.
 
 export const metadata: Metadata = {
   title: "Espérance Sportive de Tunis - Site Officiel",
@@ -83,7 +73,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="fr" className={`${playfairDisplay.variable} ${sourceSansPro.variable}`} suppressHydrationWarning>
+    <html lang="fr" className={GeistSans.variable} suppressHydrationWarning>
       <head>
         <StructuredDataScript data={generateSportsTeamStructuredData()} />
         <link rel="icon" href="/favicon.ico" />

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -1327,6 +1327,10 @@ export const standings = footballStandings2024
 export const footballSquad = footballSquad2025
 export const articles = allNews
 export const recentTrophies: Trophy[] = allTrophies.slice(0, 6).sort((a, b) => b.year - a.year)
+export const handballSquad = handballSquad2025
+export const volleyballSquad = volleyballSquad2025
+export const handballTrophies = getTrophiesBySport("handball")
+export const volleyballTrophies = getTrophiesBySport("volleyball")
 
 // Utility functions for data access
 export function getFixturesBySport(sport: "football" | "volleyball" | "handball"): Fixture[] {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,7 +18,9 @@ const nextConfig = {
   generateEtags: true,
   trailingSlash: false,
   experimental: {
-    optimizeCss: true,
+    // Disable CSS optimization that relies on the optional "critters" package
+    // to avoid build failures when the dependency isn't available.
+    optimizeCss: false,
     optimizePackageImports: ['lucide-react', 'framer-motion', '@radix-ui/react-dialog', '@radix-ui/react-dropdown-menu'],
     webVitalsAttribution: ['CLS', 'LCP'],
     scrollRestoration: true,


### PR DESCRIPTION
## Summary
- replace remote Google fonts with local Geist Sans to compile offline
- disable optional CSS optimization requiring `critters`
- export handball and volleyball data to satisfy page imports

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a341dba40483279cbc602654969b21