### PR TITLE
feat: convert squad grid to carousel

### DIFF
--- a/components/squad-grid.tsx
+++ b/components/squad-grid.tsx
@@ -1,5 +1,11 @@
-import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel"
 import type { Player } from "@/lib/mock-data"
 
 interface SquadGridProps {
@@ -16,46 +22,46 @@ export function SquadGrid({ players }: SquadGridProps) {
   }
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-      {players.map((player) => (
-        <Card
-          key={player.id}
-          className="group overflow-hidden hover:shadow-xl transition-all duration-300 hover:scale-[1.02]"
-        >
-          <div className="relative overflow-hidden">
-            <img
-              src={player.photo || "/placeholder.svg"}
-              alt={player.name}
-              className="w-full aspect-[3/4] object-cover group-hover:scale-110 transition-transform duration-300"
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-            <Badge className="absolute top-3 left-3 bg-est-rouge text-white font-bold text-lg shadow-lg">
-              {player.number}
-            </Badge>
-            <Badge className={`absolute top-3 right-3 text-xs shadow-lg ${getPositionColor(player.position)}`}>
-              {player.position}
-            </Badge>
-          </div>
-          <CardContent className="p-4">
-            <div className="space-y-3">
-              <div>
-                <h3 className="font-semibold text-lg group-hover:text-est-rouge transition-colors">
-                  {player.name}
-                </h3>
-                <p className="text-sm text-muted-foreground">{player.nationality}</p>
-              </div>
-              <div className="flex justify-between text-sm text-muted-foreground">
-                <span>
-                  <span className="font-medium">Âge:</span> {player.age} ans
-                </span>
-                <span>
-                  <span className="font-medium">Arrivé en:</span> {player.joinedYear}
-                </span>
+    <Carousel className="w-full" opts={{ align: "start", loop: true }}>
+      <CarouselContent>
+        {players.map((player) => (
+          <CarouselItem
+            key={player.id}
+            className="md:basis-1/2 lg:basis-1/3 xl:basis-1/4"
+          >
+            <div className="group relative overflow-hidden rounded-lg">
+              <img
+                src={player.photo || "/placeholder.svg"}
+                alt={player.name}
+                className="w-full aspect-[3/4] object-cover transition-transform duration-300 group-hover:scale-110"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+              <Badge className="absolute top-3 left-3 bg-est-rouge text-white font-bold text-lg shadow-lg">
+                {player.number}
+              </Badge>
+              <Badge
+                className={`absolute top-3 right-3 text-xs shadow-lg ${getPositionColor(player.position)}`}
+              >
+                {player.position}
+              </Badge>
+              <div className="absolute bottom-0 left-0 right-0 translate-y-full p-4 text-white transition-transform duration-300 backdrop-blur-sm bg-black/50 group-hover:translate-y-0">
+                <h3 className="font-semibold text-lg">{player.name}</h3>
+                <p className="text-sm opacity-90">{player.nationality}</p>
+                <div className="mt-2 flex justify-between text-xs">
+                  <span>
+                    <span className="font-medium">Âge:</span> {player.age} ans
+                  </span>
+                  <span>
+                    <span className="font-medium">Arrivé en:</span> {player.joinedYear}
+                  </span>
+                </div>
               </div>
             </div>
-          </CardContent>
-        </Card>
-      ))}
-    </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
   )
 }


### PR DESCRIPTION
## Summary
- refactor SquadGrid into Embla carousel slider
- add hover overlay without card background

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: asked for ESLint config)

------
https://chatgpt.com/codex/tasks/task_e_68a349e1c6e08327b7c71c3c6f6ef961