### PR TITLE
feat: add global translation context

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css"
 import { StructuredDataScript } from "@/components/structured-data"
 import { generateSportsTeamStructuredData } from "@/lib/structured-data"
 import { ThemeProvider } from "next-themes"
+import { TranslationProvider } from "@/lib/i18n"
 
 // Use the locally bundled Geist Sans font to avoid network requests during
 // build. This ensures the application can compile in environments without
@@ -84,7 +85,7 @@ export default function RootLayout({
       </head>
       <body className="antialiased">
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange={false}>
-          {children}
+          <TranslationProvider>{children}</TranslationProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,20 +1,17 @@
 "use client"
-import { useState } from "react"
 import Link from "next/link"
+import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { Menu, Search } from "lucide-react"
 import { LanguageSwitcher } from "@/components/language-switcher"
 import { ThemeToggle } from "@/components/theme-toggle"
-import { defaultLocale, type Locale } from "@/lib/i18n"
-import { getTranslation } from "@/lib/translations"
+import { useTranslation } from "@/lib/i18n"
 import { motion } from "framer-motion"
 
 export function Header() {
-  const [currentLocale, setCurrentLocale] = useState<Locale>(defaultLocale)
+  const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
-
-  const t = (key: any) => getTranslation(currentLocale, key)
 
   const navItems = [
     { href: "/", label: t("nav.home") },
@@ -78,7 +75,7 @@ export function Header() {
               <Search className="h-4 w-4" />
             </Button>
             <ThemeToggle />
-            <LanguageSwitcher currentLocale={currentLocale} onLocaleChange={setCurrentLocale} />
+            <LanguageSwitcher />
 
             {/* Mobile menu */}
             <Sheet open={isOpen} onOpenChange={setIsOpen}>

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,11 +1,17 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react"
+import { translations, type TranslationKey } from "./translations"
 
 export const locales = ["fr", "ar", "en"] as const
 export type Locale = (typeof locales)[number]
-
-export type TranslationKey = string
 
 export const defaultLocale: Locale = "fr"
 
@@ -21,86 +27,40 @@ export const localeDirections: Record<Locale, "ltr" | "rtl"> = {
   en: "ltr",
 }
 
-export function getDirection(locale: Locale): "ltr" | "rtl" {
-  return localeDirections[locale]
+interface TranslationContextValue {
+  locale: Locale
+  changeLocale: (locale: Locale) => void
+  t: (key: TranslationKey, fallback?: string) => string
+  direction: "ltr" | "rtl"
+  isRTL: boolean
 }
 
-export function isValidLocale(locale: string): locale is Locale {
-  return locales.includes(locale as Locale)
-}
+const TranslationContext = createContext<TranslationContextValue | undefined>(undefined)
 
-function getTranslation(locale: Locale, key: TranslationKey): string | undefined {
-  const translations: Record<TranslationKey, Record<Locale, string>> = {
-    "socialMedia.title": {
-      fr: "Suivez-nous sur les Réseaux Sociaux",
-      ar: "تابعونا على وسائل التواصل الاجتماعي",
-      en: "Follow us on Social Media",
-    },
-    "socialMedia.subtitle": {
-      fr: "Restez connectés avec l'actualité de l'EST en temps réel",
-      ar: "ابقى متصلاً مع أحدث أخبار EST بالوقت الحقيقي",
-      en: "Stay connected with EST's latest news in real-time",
-    },
-    "nav.home": {
-      fr: "Accueil",
-      ar: "الصفحة الرئيسية",
-      en: "Home",
-    },
-    "nav.news": {
-      fr: "Actualités",
-      ar: "الأخبار",
-      en: "News",
-    },
-    "nav.football": {
-      fr: "Football",
-      ar: "الكرة القدم",
-      en: "Football",
-    },
-    "nav.volleyball": {
-      fr: "Volleyball",
-      ar: "الكرة الطائرة",
-      en: "Volleyball",
-    },
-    "nav.handball": {
-      fr: "Handball",
-      ar: "الكرة اليدوية",
-      en: "Handball",
-    },
-    "nav.timeline": {
-      fr: "Histoire",
-      ar: "الجدول الزمني",
-      en: "Timeline",
-    },
-    "nav.club": {
-      fr: "Club",
-      ar: "الклاب",
-      en: "Club",
-    },
-    "nav.contact": {
-      fr: "Contact",
-      ar: "اتصال",
-      en: "Contact",
-    },
-  }
-
-  return translations[key]?.[locale]
-}
-
-export function useTranslation() {
-  const [currentLocale, setCurrentLocale] = useState<Locale>(() => {
-    if (typeof window !== "undefined") {
-      const urlParams = new URLSearchParams(window.location.search)
-      const langParam = urlParams.get("lang")
-      if (langParam && isValidLocale(langParam)) {
-        return langParam
-      }
-      const stored = localStorage.getItem("est-locale")
-      if (stored && isValidLocale(stored)) {
-        return stored
-      }
+function getInitialLocale(): Locale {
+  if (typeof window !== "undefined") {
+    const urlParams = new URLSearchParams(window.location.search)
+    const langParam = urlParams.get("lang")
+    if (langParam && locales.includes(langParam as Locale)) {
+      return langParam as Locale
     }
-    return defaultLocale
-  })
+    const stored = localStorage.getItem("est-locale")
+    if (stored && locales.includes(stored as Locale)) {
+      return stored as Locale
+    }
+  }
+  return defaultLocale
+}
+
+export function TranslationProvider({ children }: { children: ReactNode }) {
+  const [currentLocale, setCurrentLocale] = useState<Locale>(getInitialLocale)
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      document.documentElement.lang = currentLocale
+      document.documentElement.dir = localeDirections[currentLocale]
+    }
+  }, [currentLocale])
 
   const changeLocale = useCallback((newLocale: Locale) => {
     setCurrentLocale(newLocale)
@@ -114,16 +74,31 @@ export function useTranslation() {
 
   const t = useCallback(
     (key: TranslationKey, fallback?: string) => {
-      return getTranslation(currentLocale, key) || fallback || key
+      return translations[currentLocale]?.[key] || fallback || key
     },
     [currentLocale],
   )
 
-  return {
-    t,
-    locale: currentLocale,
-    changeLocale,
-    direction: getDirection(currentLocale),
-    isRTL: getDirection(currentLocale) === "rtl",
-  }
+  return (
+    <TranslationContext.Provider
+      value={{
+        locale: currentLocale,
+        changeLocale,
+        t,
+        direction: localeDirections[currentLocale],
+        isRTL: localeDirections[currentLocale] === "rtl",
+      }}
+    >
+      {children}
+    </TranslationContext.Provider>
+  )
 }
+
+export function useTranslation() {
+  const context = useContext(TranslationContext)
+  if (!context) {
+    throw new Error("useTranslation must be used within a TranslationProvider")
+  }
+  return context
+}
+


### PR DESCRIPTION
## Summary
- add TranslationProvider and useTranslation hook for global locale state
- wrap app layout in TranslationProvider
- update header to use translation hook and built-in language switcher

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68a433f045108327b679cf08af694107