### PR TITLE
Add staff and media sections to football page

### DIFF
--- a/app/football/page.tsx
+++ b/app/football/page.tsx
@@ -6,9 +6,9 @@ import { FixturesWidget } from "@/components/fixtures-widget"
 import { StandingsWidget } from "@/components/standings-widget"
 import { SquadGrid } from "@/components/squad-grid"
 import { StaffGrid } from "@/components/staff-grid"
-import { TrophiesGrid } from "@/components/trophies-grid"
+import { SocialMediaPosts } from "@/components/social-media-posts"
 import { SportNewsSection } from "@/components/sport-news-section"
-import { footballSquad, footballStaff, footballTrophies, footballFixtures, allNews } from "@/lib/mock-data"
+import { footballSquad, footballStaff, footballFixtures, allNews } from "@/lib/mock-data"
 
 export default function FootballPage() {
   const breadcrumbItems = [
@@ -52,8 +52,19 @@ export default function FootballPage() {
           </section>
 
 
+          {/* Staff */}
+          <section className="space-y-6">
+            <div className="text-center space-y-2">
+              <h2 className="font-heading text-3xl font-bold">Staff Technique</h2>
+              <p className="text-muted-foreground">Encadrement de l'équipe première</p>
+            </div>
+            <StaffGrid staff={footballStaff} />
+          </section>
+
 
         </div>
+        <SocialMediaPosts />
+
       </main>
       <Footer />
     </div>

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -589,6 +589,30 @@ export const footballSquad2025: Player[] = [
   },
 ]
 
+export const footballStaff: Staff[] = [
+  {
+    id: "staff1",
+    name: "Nabil Maaloul",
+    role: "Entraîneur principal",
+    photo: "/placeholder.svg?height=200&width=200",
+    experience: "5 ans à l'EST",
+  },
+  {
+    id: "staff2",
+    name: "Selim Ben Hassen",
+    role: "Entraîneur adjoint",
+    photo: "/placeholder.svg?height=200&width=200",
+    experience: "3 ans à l'EST",
+  },
+  {
+    id: "staff3",
+    name: "Ahmed Bejaoui",
+    role: "Préparateur physique",
+    photo: "/placeholder.svg?height=200&width=200",
+    experience: "2 ans à l'EST",
+  },
+]
+
 // Volleyball squad
 export const volleyballSquad2025: Player[] = [
   {


### PR DESCRIPTION
## Summary
- display staff and social media gallery on football page
- add mock staff data for football

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4677bc6608327a4ca0315b3d1b433