### PR TITLE
feat: add football gallery section

### DIFF
--- a/app/football/gallery/[id]/page.tsx
+++ b/app/football/gallery/[id]/page.tsx
@@ -1,0 +1,39 @@
+import { Header } from "@/components/header"
+import { Footer } from "@/components/footer"
+import { Breadcrumbs } from "@/components/breadcrumbs"
+import { footballAlbums } from "@/components/football-gallery"
+import { notFound } from "next/navigation"
+
+export default function FootballAlbumPage({ params }: { params: { id: string } }) {
+  const album = footballAlbums.find((a) => a.id.toString() === params.id)
+  if (!album) notFound()
+
+  const breadcrumbItems = [
+    { label: "Accueil", href: "/" },
+    { label: "Football", href: "/football" },
+    { label: album.title, href: `/football/gallery/${params.id}` },
+  ]
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main>
+        <Breadcrumbs items={breadcrumbItems} />
+        <div className="container mx-auto px-4 py-12 space-y-6">
+          <h1 className="font-heading text-3xl font-bold">{album.title}</h1>
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+            {album.photos.map((photo, index) => (
+              <img
+                key={index}
+                src={photo}
+                alt={`${album.title} ${index + 1}`}
+                className="w-full h-48 object-cover rounded-md"
+              />
+            ))}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/app/football/page.tsx
+++ b/app/football/page.tsx
@@ -8,6 +8,7 @@ import { SquadGrid } from "@/components/squad-grid"
 import { StaffGrid } from "@/components/staff-grid"
 import { SocialMediaPosts } from "@/components/social-media-posts"
 import { SportNewsSection } from "@/components/sport-news-section"
+import FootballGallery from "@/components/football-gallery"
 import { footballSquad, footballStaff, footballFixtures, allNews } from "@/lib/mock-data"
 
 export default function FootballPage() {
@@ -60,6 +61,8 @@ export default function FootballPage() {
             </div>
             <StaffGrid staff={footballStaff} />
           </section>
+
+          <FootballGallery />
 
 
         </div>

--- a/components/football-gallery.tsx
+++ b/components/football-gallery.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Camera, Play } from "lucide-react"
+
+export const footballAlbums = [
+  {
+    id: 1,
+    type: "image",
+    title: "Séance d'entraînement",
+    cover: "/football-training-session.png",
+    date: "2024-01-15",
+    photos: [
+      "/football-training-session.png",
+      "/football-highlights-screen.png",
+      "/est-football-victory.png",
+    ],
+  },
+  {
+    id: 2,
+    type: "image",
+    title: "Photo de groupe",
+    cover: "/est-football-victory.png",
+    date: "2024-01-20",
+    photos: [
+      "/est-football-victory.png",
+      "/football-training-session.png",
+    ],
+  },
+  {
+    id: 3,
+    type: "video",
+    title: "Résumé du match",
+    cover: "/football-highlights-screen.png",
+    date: "2024-01-25",
+    photos: [
+      "/football-highlights-screen.png",
+    ],
+    duration: "3:45",
+  },
+]
+
+export function FootballGallery() {
+  return (
+    <section className="space-y-6">
+      <div className="text-center space-y-2">
+        <h2 className="font-heading text-3xl font-bold">Galerie</h2>
+        <p className="text-muted-foreground">Photos et vidéos récentes</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {footballAlbums.map((item) => (
+          <Link key={item.id} href={`/football/gallery/${item.id}`}>
+            <Card className="group overflow-hidden hover:shadow-xl transition-all duration-300 cursor-pointer">
+              <div className="relative">
+                <img
+                  src={item.cover || "/placeholder.svg"}
+                  alt={item.title}
+                  className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
+                />
+                <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                  {item.type === "video" ? (
+                    <Play className="h-12 w-12 text-white" />
+                  ) : (
+                    <Camera className="h-12 w-12 text-white" />
+                  )}
+                </div>
+                {item.duration && (
+                  <Badge className="absolute top-3 right-3 bg-black/70 text-white">
+                    {item.duration}
+                  </Badge>
+                )}
+              </div>
+              <CardContent className="p-4">
+                <h3 className="font-semibold group-hover:text-est-rouge transition-colors">
+                  {item.title}
+                </h3>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default FootballGallery
+


### PR DESCRIPTION
## Summary
- add football gallery albums linked to dedicated pages
- show album photos on individual gallery pages

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Missing script: test)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a478a3201c832790b871cead09d41a