### PR TITLE
chore: soften light mode background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,11 +5,12 @@
 
 :root {
   /* Updated color tokens to match EST club colors (Rouge #E31E24, Jaune #FFD200) */
-  --background: oklch(1 0 0); /* White */
+  /* Use a softer white to reduce glare in light mode */
+  --background: oklch(0.985 0 0); /* Soft white */
   --foreground: oklch(0.145 0 0); /* Dark Grey #4b5563 equivalent */
-  --card: oklch(1 0 0); /* Light Grey #f9fafb equivalent */
+  --card: oklch(0.985 0 0); /* Light Grey #f9fafb equivalent */
   --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
+  --popover: oklch(0.985 0 0);
   --popover-foreground: oklch(0.145 0 0);
   --primary: oklch(0.205 0 0);
   --primary-foreground: oklch(0.985 0 0);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,11 +4,12 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(1 0 0);
+  /* Use a softer white in light mode to improve comfort */
+  --background: oklch(0.985 0 0);
   --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
+  --card: oklch(0.985 0 0);
   --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
+  --popover: oklch(0.985 0 0);
   --popover-foreground: oklch(0.145 0 0);
   --primary: oklch(0.205 0 0);
   --primary-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
## Summary
- use a softer white in light mode backgrounds to reduce glare

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: How would you like to configure ESLint? prompt)


------
https://chatgpt.com/codex/tasks/task_e_68a5d7eeb0c48327a12aaf44f6b93b30