### PR TITLE
Add club identity slogan

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -31,6 +31,9 @@ export function Header() {
       transition={{ duration: 0.6, ease: "easeOut" }}
       className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 shadow-sm"
     >
+      <div className="bg-est-rouge text-est-jaune text-center text-xs sm:text-sm font-semibold py-1">
+        Taraji Ya Dawla – <span dir="rtl" className="mx-1">نحن الترجي</span>
+      </div>
       <div className="container mx-auto px-4">
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -51,6 +51,9 @@ export function HeroSection() {
 
   return (
     <section className="relative h-[70vh] min-h-[500px] overflow-hidden bg-gradient-to-r from-est-rouge/90 to-est-rouge/70">
+      <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 bg-est-rouge text-est-jaune px-4 py-1 rounded-full text-sm font-bold shadow">
+        Taraji Ya Dawla • <span dir="rtl" className="mx-1">نحن الترجي</span>
+      </div>
       <AnimatePresence mode="wait">
         <motion.div
           key={currentSlide}


### PR DESCRIPTION
## Summary
- Add red and yellow top bar in header with motto "Taraji Ya Dawla – نحن الترجي"
- Overlay same slogan on hero section for stronger club identity

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (interactive prompt: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68a5e89f6e388327a02ad5b95c40f565