### PR TITLE
Animate club identity banner

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -31,6 +31,15 @@ export function Header() {
       transition={{ duration: 0.6, ease: "easeOut" }}
       className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 shadow-sm"
     >
+      <div className="relative overflow-hidden">
+        <div
+          aria-hidden
+          className="absolute inset-0 bg-[length:200%_100%] bg-gradient-to-r from-est-rouge via-est-jaune to-est-rouge animate-banner"
+        />
+        <div className="relative text-white text-center text-xs sm:text-sm font-semibold py-1 drop-shadow-md">
+          Taraji Ya Dawla – <span dir="rtl" className="mx-1">نحن الترجي</span>
+        </div>
+      </div>
       <div className="container mx-auto px-4">
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -51,6 +51,19 @@ export function HeroSection() {
 
   return (
     <section className="relative h-[70vh] min-h-[500px] overflow-hidden bg-gradient-to-r from-est-rouge/90 to-est-rouge/70">
+      <motion.div
+        initial={{ y: -20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ duration: 0.6 }}
+        className="absolute top-6 left-1/2 -translate-x-1/2 z-20"
+      >
+        <div className="relative px-6 py-2">
+          <div className="absolute inset-0 bg-[length:200%_100%] bg-gradient-to-r from-est-rouge via-est-jaune to-est-rouge rounded-full shadow-lg animate-banner" />
+          <span className="relative block text-sm font-extrabold text-white drop-shadow">
+            Taraji Ya Dawla • <span dir="rtl" className="mx-1">نحن الترجي</span>
+          </span>
+        </div>
+      </motion.div>
       <AnimatePresence mode="wait">
         <motion.div
           key={currentSlide}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -122,3 +122,18 @@
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes banner-scroll {
+  from {
+    background-position: 0% 0%;
+  }
+  to {
+    background-position: 200% 0%;
+  }
+}
+
+@layer utilities {
+  .animate-banner {
+    animation: banner-scroll 8s linear infinite;
+  }
+}


### PR DESCRIPTION
## Summary
- Upgrade header motto into an animated red-yellow gradient bar with drop-shadow text
- Overlay matching animated ribbon on hero section for stronger club branding
- Add `animate-banner` utility with keyframes for reusable gradient motion

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (interactive prompt: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68a5e89f6e388327a02ad5b95c40f565