### PR TITLE
Fix build by closing unbalanced div in header

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -39,6 +39,7 @@ export function Header() {
         <div className="relative text-white text-center text-xs sm:text-sm font-semibold py-1 drop-shadow-md">
           Taraji Ya Dawla – <span dir="rtl" className="mx-1">نحن الترجي</span>
         </div>
+        </div>
 
       <div className="container mx-auto px-4">
         <div className="flex h-16 items-center justify-between">


### PR DESCRIPTION
## Summary
- close missing wrapper `div` in `header` component to restore valid JSX

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d11da9b0832795842f4dd79408ce