### PR TITLE
feat: add secondary identity strip variant

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,21 +16,21 @@ export default function HomePage() {
       <Header />
       <main>
         <HeroSection />
-        <IdentityStrip />
+        <IdentityStrip variant="primary" />
         <div className="container mx-auto px-4 py-8 space-y-12">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
             <NextMatchWidget />
             <MiniStandingsWidget />
           </div>
-          <IdentityStrip />
+          <IdentityStrip variant="secondary" />
           <LatestNewsSection />
-          <IdentityStrip />
+          <IdentityStrip variant="primary" />
           <SocialMediaPosts />
-          <IdentityStrip />
+          <IdentityStrip variant="secondary" />
           <AroundClubSection />
-          <IdentityStrip />
+          <IdentityStrip variant="primary" />
           <PalmaresPreview />
-          <IdentityStrip />
+          <IdentityStrip variant="secondary" />
           <NewsletterSignup />
         </div>
       </main>

--- a/components/identity-strip.md
+++ b/components/identity-strip.md
@@ -1,0 +1,13 @@
+# IdentityStrip
+
+Thin animated banner used to break up content sections.
+
+## Variants
+
+- **primary** – classic red→yellow→red gradient, taller height.
+- **secondary** – alternate yellow→red→yellow gradient, slightly shorter.
+
+```tsx
+<IdentityStrip variant="primary" />
+<IdentityStrip variant="secondary" />
+```

--- a/components/identity-strip.tsx
+++ b/components/identity-strip.tsx
@@ -2,16 +2,46 @@
 
 import { motion } from "framer-motion"
 
-export function IdentityStrip() {
+/**
+ * IdentityStrip renders a thin animated banner used to separate content blocks.
+ *
+ * Use `variant="primary"` for the classic red-yellow-red gradient and `variant="secondary"`
+ * for the alternate yellow-red-yellow look. Both variants scroll horizontally and display
+ * the club motto in the center.
+ */
+export function IdentityStrip({
+  variant = "primary",
+}: {
+  /**
+   * Visual style of the strip. "primary" uses red-yellow-red gradient and taller height,
+   * while "secondary" swaps the colors and reduces the height for subtle separation.
+   */
+  variant?: "primary" | "secondary"
+}) {
+  const variants = {
+    primary: {
+      wrapper: "h-8",
+      gradient: "bg-gradient-to-r from-est-rouge via-est-jaune to-est-rouge",
+    },
+    secondary: {
+      wrapper: "h-6",
+      gradient: "bg-gradient-to-r from-est-jaune via-est-rouge to-est-jaune",
+    },
+  }
+
+  const { wrapper, gradient } = variants[variant]
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.5 }}
-      className="relative left-1/2 -translate-x-1/2 w-screen h-8 overflow-hidden"
+      className={`relative left-1/2 -translate-x-1/2 w-screen overflow-hidden ${wrapper}`}
     >
-      <div className="absolute inset-0 bg-[length:200%_100%] bg-gradient-to-r from-est-rouge via-est-jaune to-est-rouge animate-banner" />
+      <div
+        className={`absolute inset-0 bg-[length:200%_100%] ${gradient} animate-banner`}
+      />
       <p className="relative z-10 h-full flex items-center justify-center text-xs sm:text-sm md:text-base font-heading font-extrabold tracking-widest uppercase text-white drop-shadow">
         Taraji Ya Dawla – <span dir="rtl" className="mx-1">نحن الترجي</span>
       </p>


### PR DESCRIPTION
## Summary
- add `secondary` style to `IdentityStrip` component
- alternate `primary`/`secondary` strips on homepage
- document IdentityStrip variants in component and style guide

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a83d2fdb048327863c15dcb9ee1080